### PR TITLE
Binding socket to specific network interface

### DIFF
--- a/examples/bind_socket_iface.py
+++ b/examples/bind_socket_iface.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+'''
+this example is for those who use multiple network interface
+In my case, I connected my Raspberry pi's interface
+ eth0 : to internet
+ wlan0 : to sony camera, a5100 specifically
+Normally pysony doesn't work in this case. Because socket sends ssdp only to eth0
+I modified ControlPoint's init function so socket object in ControlPoint to be bound to wlan0
+'''
+
+import pysony
+
+print("Searching for camera...")
+
+search = pysony.ControlPoint(interface='wlan0')
+cameras =  search.discover()
+
+if len(cameras):
+    camera = pysony.SonyAPI(QX_ADDR=cameras[0])
+else:
+    print("No camera found, aborting")
+    quit()

--- a/src/pysony.py
+++ b/src/pysony.py
@@ -38,12 +38,14 @@ logger = logging.getLogger(__name__)
 # Improved with code from 'https://github.com/storborg/sonypy' under MIT license.
 
 class ControlPoint(object):
-    def __init__(self, addr=SSDP_ADDR, port=SSDP_PORT):
+    def __init__(self, addr=SSDP_ADDR, port=SSDP_PORT, interface=None):
         self.addr, self.port = addr, port
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.settimeout(0.1)
         # Set the socket to broadcast mode.
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
+        if interface:
+          sock.setsockopt(socket.SOL_SOCKET, 25, str(interface + '\0').encode('utf-8'))
         self._udp_socket = sock
 
     def close(self):


### PR DESCRIPTION
Hello. Thanks a lot for wonderful library.

I'm using it in my Raspberry pi
My RPi's
eth0 is connected to company network
wlan0 is connected to A5100 sony mirrorless camera

I guess ControlPoint's socket is kinda stick to eth0.
So I modified ControlPoint to support binding socket socket to specific interface.

I hope this may helpful.