### PR TITLE
Bug67: Don't assume camera can use latest version of 'getEvent()'

### DIFF
--- a/examples/pyLiveView.py
+++ b/examples/pyLiveView.py
@@ -145,7 +145,7 @@ class liveview_grabber(threading.Thread):
       lst.start()
 
       versions = camera.getVersions()
-      if versions and type(versions) == dict and 'result' in versions.keys():
+      if versions and 'result' in versions.keys():
          version = versions['result'][-1]
       else:
          version = '1.0'
@@ -157,7 +157,7 @@ class liveview_grabber(threading.Thread):
          else:
             mode = None
 
-         if mode and type(mode) == dict and 'result' in mode.keys():
+         if mode and 'result' in mode.keys():
             status = mode['result'][1]
             if self.active == False and status['cameraStatus'] == 'MovieRecording':
                self.frame_count = 0

--- a/examples/pyLiveView.py
+++ b/examples/pyLiveView.py
@@ -144,14 +144,20 @@ class liveview_grabber(threading.Thread):
       lst = SonyAPI.LiveviewStreamThread(url)
       lst.start()
 
+      versions = camera.getVersions()
+      if versions and type(versions) == dict and 'result' in versions.keys():
+         version = versions['result'][-1]
+      else:
+         version = '1.0'
+
       while not self.event_terminate.isSet():
          # Handle events from the camera (record start/stop)
          if self.frame_count % 50 == 0:
-            mode = camera.getEvent(["false"])
+            mode = camera.getEvent(["false"], version=version)
          else:
             mode = None
 
-         if mode and type(mode) == dict:
+         if mode and type(mode) == dict and 'result' in mode.keys():
             status = mode['result'][1]
             if self.active == False and status['cameraStatus'] == 'MovieRecording':
                self.frame_count = 0


### PR DESCRIPTION
Older cameras error when code requests to use newest version of 'getEvent()', this code snippet checks which versions the camera actually supports and uses the latest supported.

Failure seen on my QX10. Reported in #67
```
simon@thevoid:~/sony_camera_api-github$ python2 examples/pyLiveView.py -g
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "examples/pyLiveView.py", line 155, in run
    status = mode['result'][1]
KeyError: 'result'

^CKilled
```