### PR TITLE
Added API functions for shooting in BULB mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Pycharm
+.idea/

--- a/src/api_list.py
+++ b/src/api_list.py
@@ -194,7 +194,9 @@ no_param = ["getShootMode",
             "getAvailableApiList",
             "getApplicationInfo",
             "getVersions",
-            "getMethodTypes"] #  camera, system and avContent
+            "getMethodTypes",
+            "startBulbShooting",
+            "stopBulbShooting"] #  camera, system and avContent
 
 params = [{"name":"shoot mode",
            "value": ["still", "movie", "audio", "intervalstill"],

--- a/src/pysony.py
+++ b/src/pysony.py
@@ -1061,3 +1061,9 @@ class SonyAPI():
 
     def getVersions(self, target=None, version='1.0'):
         return self._cmd(method="getVersions", target=target, version=version)
+
+    def startBulbShooting(self, version='1.0'):
+        return self._cmd(method="startBulbShooting", version=version)
+
+    def stopBulbShooting(self, version='1.0'):
+        return self._cmd(method="stopBulbShooting", version=version)


### PR DESCRIPTION
Amazing library, thanks a lot!

I came across API methods for using BULB mode using the WiFi remote control. I've added two functions to the standard api functions in the library:
1. startBulbShooting
2. stopBulbShooting

I've tested this on my A6000